### PR TITLE
tweak the sprint review agenda

### DIFF
--- a/ProjectBoard.md
+++ b/ProjectBoard.md
@@ -60,9 +60,9 @@ The Sprint Review includes the following elements:
 
 General agenda (with max time for each):
 
-1. 5 mins: `Blocked`
-1. 5 mins: `New Issues`
 1. 40 mins: Go through all issues in `Done` with demos as applicable
+1. 5 mins: `In progress`
+1. 5 mins: `Waiting/Blocked`
 1. 10 mins: Q&A and suggestions from stakeholders
 
 ## Epics


### PR DESCRIPTION
A couple proposed changes:

- I'm not sure that the `New issues` will be that useful for folks to see (since they aren't necessarily groomed or prioritized, so we can speak to them if they come up in Q&A.
- The order now mirrors standups, which are:
  1. What did we work on
  1. What are we working on next
  1. What are our blockers

Let's wait for the full team to approve before merging.