### PR TITLE
create an issue template for the Ops Rotation

### DIFF
--- a/.github/ISSUE_TEMPLATE/ops.md
+++ b/.github/ISSUE_TEMPLATE/ops.md
@@ -1,0 +1,37 @@
+---
+name: Operations Rotation
+about: Tasks to be completed during each Operations Rotation
+title: "Ops Rotation <start>-<end>"
+labels: ""
+assignees: ""
+---
+
+Each of the following should be done within the dates above.
+
+## Meetings
+
+- [ ] Lead [Planning Ceremony](https://github.com/18F/tts-tech-portfolio/blob/master/ProjectBoard.md#planning-ceremony)
+  - [ ] Review board prior to meeting
+- [ ] Lead the daily standup
+- [ ] Attend the CTO Liaison Meeting
+  - [ ] Review and update [Trello board](https://trello.com/b/BFp37KQ6/gsa-cto-tts-liaison)
+- [ ] Lead [Sprint Review](https://github.com/18F/tts-tech-portfolio/blob/master/ProjectBoard.md#sprint-reviews)
+- [ ] Lead [Retro](https://github.com/18F/tts-tech-portfolio/blob/master/ProjectBoard.md#retros)
+- [ ] Let the next person on Operations Rotation know what is outstanding
+
+## GitHub
+
+- [ ] Review and ideally merge (or close) [open pull requests to Tech Portfolio repositories](https://github.com/search?utf8=%E2%9C%93&q=state%3Aopen+is%3Apr+repo%3A18F%2Faws-admin+repo%3A18F%2Fghad+repo%3A18F%2Ftts-tech-portfolio+repo%3A18F%2Fvulnerability-disclosure-policy+repo%3A18F%2FDNS+repo%3A18f%2Fhandbook+repo%3A18F%2Fbefore-you-ship+repo%3A18F%2Fchandika+repo%3A18F%2Fopen-source-policy+repo%3A18F%2Flaptop+repo%3A18F%2Fchat+repo%3A18F%2Fbug-bounty+repo%3A18F%2Flaptop++repo%3A18F%2Fraktabija&type=Issues&ref=advsearch&l=&l=)
+- [ ] [Update the public IT Standards dataset](https://github.com/GSA/data/tree/master/enterprise-architecture#updating-the-list)
+- [ ] Send nudges on [open security upgrade pull requests](https://github.com/search?o=asc&q=user%3A18F+user%3AGSA+author%3Aapp%2Fdependabot+is%3Aopen+archived%3Afalse&s=created&type=Issues) that are older than a few days
+
+## Communications Monitoring
+
+Ensure you are present in the following and are responding as needed:
+
+- [ ] [Slack Channels](https://github.com/18F/tts-tech-portfolio/blob/master/Operations%20Rotation%20-%20Playbook.md#slack-channels)
+- [ ] [Google Groups](https://github.com/18F/tts-tech-portfolio/blob/master/Operations%20Rotation%20-%20Playbook.md#google-groups)
+
+## Other
+
+- Perform any outstanding [`ACCOUNT DEACTIVATION` offboarding tasks](https://docs.google.com/spreadsheets/d/1IlFY5AAvTyuS7yDHk5_odJGHYZDU_MN9HNGKJ2zXwi0/edit)

--- a/.github/ISSUE_TEMPLATE/ops.md
+++ b/.github/ISSUE_TEMPLATE/ops.md
@@ -17,6 +17,7 @@ Each of the following should be done within the dates above. See the [playbook](
   - [ ] Review and update [Trello board](https://trello.com/b/BFp37KQ6/gsa-cto-tts-liaison)
 - [ ] Lead [Sprint Review](https://github.com/18F/tts-tech-portfolio/blob/master/ProjectBoard.md#sprint-reviews)
 - [ ] Lead [Retro](https://github.com/18F/tts-tech-portfolio/blob/master/ProjectBoard.md#retros)
+  - [ ] Move Action Items into issues
 - [ ] Let the next person on Operations Rotation know what is outstanding
 
 ## GitHub

--- a/.github/ISSUE_TEMPLATE/ops.md
+++ b/.github/ISSUE_TEMPLATE/ops.md
@@ -36,3 +36,4 @@ Ensure you are present in the following and are responding as needed:
 ## Other
 
 - [ ] Perform any outstanding `ACCOUNT DEACTIVATION` [offboarding tasks](https://docs.google.com/spreadsheets/d/1IlFY5AAvTyuS7yDHk5_odJGHYZDU_MN9HNGKJ2zXwi0/edit)
+- [ ] Check and act on open [Bug Bounty reports](https://hackerone.com/bugs)

--- a/.github/ISSUE_TEMPLATE/ops.md
+++ b/.github/ISSUE_TEMPLATE/ops.md
@@ -25,6 +25,7 @@ Each of the following should be done within the dates above. See the [playbook](
 - [ ] Review and ideally merge (or close) [open pull requests to Tech Portfolio repositories](https://github.com/search?utf8=%E2%9C%93&q=state%3Aopen+is%3Apr+repo%3A18F%2Faws-admin+repo%3A18F%2Fghad+repo%3A18F%2Ftts-tech-portfolio+repo%3A18F%2Fvulnerability-disclosure-policy+repo%3A18F%2FDNS+repo%3A18f%2Fhandbook+repo%3A18F%2Fbefore-you-ship+repo%3A18F%2Fchandika+repo%3A18F%2Fopen-source-policy+repo%3A18F%2Flaptop+repo%3A18F%2Fchat+repo%3A18F%2Fbug-bounty+repo%3A18F%2Flaptop++repo%3A18F%2Fraktabija&type=Issues&ref=advsearch&l=&l=)
 - [ ] [Update the public IT Standards dataset](https://github.com/GSA/data/tree/master/enterprise-architecture#updating-the-list)
 - [ ] Send nudges on [open security upgrade pull requests](https://github.com/search?o=asc&q=user%3A18F+user%3AGSA+author%3Aapp%2Fdependabot+is%3Aopen+archived%3Afalse&s=created&type=Issues) that are older than a few days
+- [ ] Remove stale [invitations](https://github.com/orgs/18F/people)
 
 ## Communications Monitoring
 

--- a/.github/ISSUE_TEMPLATE/ops.md
+++ b/.github/ISSUE_TEMPLATE/ops.md
@@ -6,7 +6,7 @@ labels: ""
 assignees: ""
 ---
 
-Each of the following should be done within the dates above.
+Each of the following should be done within the dates above. See the [playbook](https://github.com/18F/tts-tech-portfolio/blob/master/Operations%20Rotation%20-%20Playbook.md) for additional info.
 
 ## Meetings
 

--- a/.github/ISSUE_TEMPLATE/ops.md
+++ b/.github/ISSUE_TEMPLATE/ops.md
@@ -34,4 +34,4 @@ Ensure you are present in the following and are responding as needed:
 
 ## Other
 
-- Perform any outstanding [`ACCOUNT DEACTIVATION` offboarding tasks](https://docs.google.com/spreadsheets/d/1IlFY5AAvTyuS7yDHk5_odJGHYZDU_MN9HNGKJ2zXwi0/edit)
+- [ ] Perform any outstanding `ACCOUNT DEACTIVATION` [offboarding tasks](https://docs.google.com/spreadsheets/d/1IlFY5AAvTyuS7yDHk5_odJGHYZDU_MN9HNGKJ2zXwi0/edit)

--- a/.github/ISSUE_TEMPLATE/ops.md
+++ b/.github/ISSUE_TEMPLATE/ops.md
@@ -38,3 +38,4 @@ Ensure you are present in the following and are responding as needed:
 
 - [ ] Perform any outstanding `ACCOUNT DEACTIVATION` [offboarding tasks](https://docs.google.com/spreadsheets/d/1IlFY5AAvTyuS7yDHk5_odJGHYZDU_MN9HNGKJ2zXwi0/edit)
 - [ ] Check and act on open [Bug Bounty reports](https://hackerone.com/bugs)
+- [ ] Go through [General Requests Form responses](https://docs.google.com/spreadsheets/d/15UT10wouN2wuYABN02npzg8ETH3PFlFdXBWPJTsP3Hw/edit#gid=2127744834)

--- a/Operations Rotation - Playbook.md
+++ b/Operations Rotation - Playbook.md
@@ -1,6 +1,6 @@
 # Operations Rotation Playbook
 
-[Create an issue using the Operations Rotation template](https://github.com/18F/tts-tech-portfolio/issues/new?template=ops.md) before each Rotation to track tasks.
+[Create an issue using the Operations Rotation template](https://github.com/18F/tts-tech-portfolio/issues/new?template=ops.md) before each Rotation to track tasks. Close once the rotation has ended.
 
 ## Micropurchase Requests
 

--- a/Operations Rotation - Playbook.md
+++ b/Operations Rotation - Playbook.md
@@ -36,7 +36,6 @@
 - #admins-trello
 - #admins-zoom
 - #bug-bounty-partners
-- #bug-bounty-partners
 - #cto-tts-liason-private
 - #devops-public
 - #incident-response
@@ -46,7 +45,6 @@
 - #questions
 - #solutions
 - #tts-shared-services
-- #tts-tech-portfolio
 - #tts-tech-portfolio
 - #tts-tech-portfolio-alerts
 

--- a/Operations Rotation - Playbook.md
+++ b/Operations Rotation - Playbook.md
@@ -77,34 +77,34 @@
 
 ## Communications Monitoring
 
-- Slack Channels
+### Slack Channels
 
-1. #admins-aws
-1. #admins-dmarc
-1. #admins-mural
-1. #admins-slack
-1. #admins-trello
-1. #admins-zoom
-1. #it-issues
-1. #tts-tech-portfolio
-1. #infrastructure
-1. #admings-github
-1. #admins-dns
-1. #admins-govdelivery
-1. #bug-bounty-partners
-1. #cto-tts-liason-private
-1. #tts-tech-portfolio-alerts
-1. #mac
-1. #bug-bounty-partners
-1. #tts-shared-services
-1. #tts-tech-portfolio
-1. #incident-response
-1. #questions
-1. #devops-public
-1. #solutions
-1. #admins
+- #admins-github
+- #admins-aws
+- #admins-dmarc
+- #admins-dns
+- #admins-govdelivery
+- #admins-iaas
+- #admins-mural
+- #admins-slack
+- #admins-trello
+- #admins-zoom
+- #bug-bounty-partners
+- #bug-bounty-partners
+- #cto-tts-liason-private
+- #devops-public
+- #incident-response
+- #infrastructure
+- #it-issues
+- #mac
+- #questions
+- #solutions
+- #tts-shared-services
+- #tts-tech-portfolio
+- #tts-tech-portfolio
+- #tts-tech-portfolio-alerts
 
-- Google Groups
+### Google Groups
 
 | Group                     | Permission |
 | ------------------------- | ---------- |

--- a/Operations Rotation - Playbook.md
+++ b/Operations Rotation - Playbook.md
@@ -1,62 +1,8 @@
-# TTS Tech Portfolio- Operations Rotation
+# Operations Rotation Playbook
 
-## Playbook
+[Create an issue using the Operations Rotation template](https://github.com/18F/tts-tech-portfolio/issues/new?template=ops.md) before each Rotation to track tasks.
 
-### Meetings
-
-> Play: Infrastructure Meeting
-
-- Review action items 32 hrs in advance
-- Follow up on any items
-- Compile agenda 48 hrs in advance
-- Send agenda 24 hrs in advance
-- Lead meeting
-
-> Play: CTO Liaison Meeting
-
-- Review [trello board](https://trello.com/b/BFp37KQ6/gsa-cto-tts-liaison)
-
-> Play: Scrum - Sprint Planning
-
-- Review board prior to meeting
-
-> Play: Scrum - Daily Standup
-
-- Lead meeting
-
-> Play: Scrum - Review/Retro
-
-- Lead retro
-
-> Play: Operations Rotation - Handover
-
-### DNS
-
-> Play: DNS Activity
-> Documentation: [DNS Handbook page](https://github.com/18F/dns)
-
-### Pull Requests
-
-[Pull Requests for Responsible TTS Tech Portfolio Repository](https://github.com/search?utf8=%E2%9C%93&q=state%3Aopen+is%3Apr+repo%3A18F%2Faws-admin+repo%3A18F%2Fghad+repo%3A18F%2Ftts-tech-portfolio+repo%3A18F%2Fvulnerability-disclosure-policy+repo%3A18F%2FDNS+repo%3A18f%2Fhandbook+repo%3A18F%2Fbefore-you-ship+repo%3A18F%2Fchandika+repo%3A18F%2Fopen-source-policy+repo%3A18F%2Flaptop+repo%3A18F%2Fchat+repo%3A18F%2Fbug-bounty+repo%3A18F%2Flaptop++repo%3A18F%2Fraktabija&type=Issues&ref=advsearch&l=&l=)
-
-### Data
-
-- [Updating the public IT Standards dataset](https://github.com/GSA/data/tree/master/enterprise-architecture#updating-the-list)
-
-## Security
-
-> Play: GitHubSecurity
-> Documentation: [18F Security Issues Page on GitHub](https://github.com/search?o=asc&q=user%3A18F+user%3AGSA+author%3Aapp%2Fdependabot+is%3Aopen+archived%3Afalse&s=created&type=Issues)
-
-> Play: Security Triaging
-> [Notes](https://docs.google.com/document/d/10OrSjLKdi2FssAMLZDnKne79r7V9hy-D2pmqWXA703k/edit)
-
-- HackerOne:
-  -- #bug-bounty-partners
-- Incidents
-  -- #incident-response
-
-### Micropurchase Requests
+## Micropurchase Requests
 
 > Play: Micropurchase Procedure
 
@@ -180,8 +126,9 @@ If employees are asking to be removed from Omigraffle, this software does not ha
 > [Sublime License Key](https://docs.google.com/document/d/18k8yuM9oXQA7MNr-qvfq8gXliSHOb_bWElohb-KaObw/edit#)
 
 > Play: AWS Software Request
-> [AWS Account Setup](https://docs.google.com/document/d/1gHTa3w-N8jyPXK_qx2bEDniFcUOTlAvITYiQI_G8lrY/edit)
-> [AWS Accounts](https://docs.google.com/spreadsheets/d/1DedSCiU9AsCAAVvAFZT0_Ii7AFIKlI-JNifzlpHNbDg/edit#gid=807365900)
+
+- [AWS Account Setup](https://docs.google.com/document/d/1gHTa3w-N8jyPXK_qx2bEDniFcUOTlAvITYiQI_G8lrY/edit)
+- [AWS Accounts](https://docs.google.com/spreadsheets/d/1DedSCiU9AsCAAVvAFZT0_Ii7AFIKlI-JNifzlpHNbDg/edit#gid=807365900)
 
 > Play: Sandbox accounts Software Request
 > [sandbox accounts](https://docs.google.com/spreadsheets/d/1DedSCiU9AsCAAVvAFZT0_Ii7AFIKlI-JNifzlpHNbDg/edit#gid=807365900)
@@ -209,9 +156,3 @@ If employees are asking to be removed from Omigraffle, this software does not ha
 > Play: Adobe Software Request
 
 - Canned Response: \_Please request through the Service Desk. Updating the Handbook with info about this.
-
-### Play Manage Software Requests (Offboarding)
-
-Remember, it is not all giving out license, you have to take them away too! TTS Talent will reach out to the current SaaS PM to send them this [document](https://docs.google.com/spreadsheets/d/1IlFY5AAvTyuS7yDHk5_odJGHYZDU_MN9HNGKJ2zXwi0/edit) so that they can check off the boxes of when they have either manually removed or requested removal of a former employee from the software.\_
-
-Simply go into both the software back-end account and remove the individual, then go in and update the user lists by deleting the cell with the person’s name and information.


### PR DESCRIPTION
This pull request doesn't make a substantive change to the Ops Rotation itself; just makes the tasks easier to track. On top of making the checklist, this pull request:

- Alphabetically ordered and updated the Slack channel list
- Made a few corrections
- Reworded the tasks to be action-oriented
- Added some tasks that were missing
- Consolidated some tasks

In other words, this splits the "what" from the "how". Testing it out in https://github.com/18F/tts-tech-portfolio/issues/347. Thoughts?

## Follow-up tasks

- [ ] [Delete Slack reminders](https://slack.com/help/articles/208423427-Set-a-reminder#delete-a-reminder) that are covered by this checklist