### PR TITLE
update labels from deep sprint planning

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,6 +27,8 @@ variable "issue_labels" {
     "RS.IM - Response Improvements"                      = "FFFFFF"
     "RS.MI - Mitigation"                                 = "FFFFFF"
     "RS.RP - Response Planning"                          = "FFFFFF"
+    "groomed: delegate"                                    = "d5bfff"
+    "groomed: decide"                                    = "d5bfff"
     "groomed: accepted"                                  = "d5bfff"
     "groomed: draft - final"                             = "d5bfff"
     "grooming: draft - initial"                          = "d5bfff"


### PR DESCRIPTION
added the delegate and decide label.

I added these to the middle of the stack; not sure if that will change the IDs of all of them and mess things up royally and if this should be added to the bottom; but we'll see! (also not sure how well reverting works for IaC...)