### PR TITLE
Terraform: switch from using `count` to `for_each`

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = "~> 0.12.6"
+}
+
 provider "github" {
   token        = var.github_token
   organization = "18f"
@@ -9,70 +13,70 @@ data "github_repository" "tts-tech-portfolio" {
 
 resource "github_issue_label" "tts-tech-portfolio" {
   repository = "tts-tech-portfolio"
-  count      = length(var.issue_labels)
-  name       = element(keys(var.issue_labels), count.index)
-  color      = element(values(var.issue_labels), count.index)
+  for_each   = var.issue_labels
+  name       = each.key
+  color      = each.value
 }
 
 resource "github_issue_label" "tts-tech-portfolio-private" {
   repository = "tts-tech-portfolio-private"
-  count      = length(var.issue_labels)
-  name       = element(keys(var.issue_labels), count.index)
-  color      = element(values(var.issue_labels), count.index)
+  for_each   = var.issue_labels
+  name       = each.key
+  color      = each.value
 }
 
 resource "github_issue_label" "ghad" {
   repository = "ghad"
-  count      = length(var.issue_labels)
-  name       = element(keys(var.issue_labels), count.index)
-  color      = element(values(var.issue_labels), count.index)
+  for_each   = var.issue_labels
+  name       = each.key
+  color      = each.value
 }
 
 resource "github_issue_label" "laptop" {
   repository = "laptop"
-  count      = length(var.issue_labels)
-  name       = element(keys(var.issue_labels), count.index)
-  color      = element(values(var.issue_labels), count.index)
+  for_each   = var.issue_labels
+  name       = each.key
+  color      = each.value
 }
 
 resource "github_issue_label" "aws-admin" {
   repository = "aws-admin"
-  count      = length(var.issue_labels)
-  name       = element(keys(var.issue_labels), count.index)
-  color      = element(values(var.issue_labels), count.index)
+  for_each   = var.issue_labels
+  name       = each.key
+  color      = each.value
 }
 
 resource "github_issue_label" "bug-bounty" {
   repository = "bug-bounty"
-  count      = length(var.issue_labels)
-  name       = element(keys(var.issue_labels), count.index)
-  color      = element(values(var.issue_labels), count.index)
+  for_each   = var.issue_labels
+  name       = each.key
+  color      = each.value
 }
 
 resource "github_issue_label" "before-you-ship" {
   repository = "before-you-ship"
-  count      = length(var.issue_labels)
-  name       = element(keys(var.issue_labels), count.index)
-  color      = element(values(var.issue_labels), count.index)
+  for_each   = var.issue_labels
+  name       = each.key
+  color      = each.value
 }
 
 resource "github_issue_label" "dns" {
   repository = "dns"
-  count      = length(var.issue_labels)
-  name       = element(keys(var.issue_labels), count.index)
-  color      = element(values(var.issue_labels), count.index)
+  for_each   = var.issue_labels
+  name       = each.key
+  color      = each.value
 }
 
 resource "github_issue_label" "vulnerability-disclosure-policy" {
   repository = "vulnerability-disclosure-policy"
-  count      = length(var.issue_labels)
-  name       = element(keys(var.issue_labels), count.index)
-  color      = element(values(var.issue_labels), count.index)
+  for_each   = var.issue_labels
+  name       = each.key
+  color      = each.value
 }
 
 resource "github_issue_label" "handbook" {
   repository = "handbook"
-  count      = length(var.issue_labels)
-  name       = element(keys(var.issue_labels), count.index)
-  color      = element(values(var.issue_labels), count.index)
+  for_each   = var.issue_labels
+  name       = each.key
+  color      = each.value
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,7 +13,6 @@ variable "issue_labels" {
     "ID.RA - Risk Assessment"                            = "FFFFFF"
     "ID.RM - Risk Management Strategy"                   = "FFFFFF"
     "ID.SC - Supply Chain Risk Management"               = "FFFFFF"
-    "ID.SC - Supply Chain Risk Management"               = "FFFFFF"
     "PR.AC - Identity Management and Access Control"     = "FFFFFF"
     "PR.AT - Awareness and Training"                     = "FFFFFF"
     "PR.DS - Data Security"                              = "FFFFFF"


### PR DESCRIPTION
When new labels are added, the indexes would get shifted, causing all the labels to be recreated. This solves that problem by using the new `for_each`, which ties the Terraform resource ID to the label name.

There was a one-time switch of resource IDs (https://github.com/hashicorp/terraform/issues/9048), so I wrote the following script to generate the commands:

```python
import json

# look at a state file from before the `mv`s were done
with open('terraform.tfstate.1582661391.backup') as f:
  state = json.load(f)

for resource in state['resources']:
    if not (resource['type'] == 'github_issue_label' and resource['mode'] == 'managed'):
        continue

    for instance in resource['instances']:
        repo = instance['attributes']['repository']
        label = instance['attributes']['name']
        index = instance['index_key']

        print(f"terraform state mv 'github_issue_label.{repo}[{index}]' 'github_issue_label.{repo}[\"{label}\"]'")
```

This generated

```sh
terraform state mv 'github_issue_label.aws-admin[0]' 'github_issue_label.aws-admin["DE.AE - Anomalies and Events"]'
terraform state mv 'github_issue_label.aws-admin[1]' 'github_issue_label.aws-admin["DE.CM - Security Continuous Monitoring"]'
terraform state mv 'github_issue_label.aws-admin[2]' 'github_issue_label.aws-admin["DE.DP- Detection Processes"]'
…
```

which I ran locally. Ran a `terraform apply` and confirmed there was no remaining change, meaning the migration worked.

```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```