### PR TITLE
copy issue template to other repositories with Terraform

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,14 +1,13 @@
 terraform {
   required_version = "~> 0.12.6"
+  required_providers {
+    github = "~> 2.4"
+  }
 }
 
 provider "github" {
   token        = var.github_token
   organization = "18f"
-}
-
-data "github_repository" "tts-tech-portfolio" {
-  full_name = "18f/tts-tech-portfolio"
 }
 
 resource "github_issue_label" "tts-tech-portfolio" {
@@ -44,6 +43,12 @@ resource "github_issue_label" "aws-admin" {
   for_each   = var.issue_labels
   name       = each.key
   color      = each.value
+}
+
+module "aws-admin" {
+  source = "./repo"
+
+  repo = "aws-admin"
 }
 
 resource "github_issue_label" "bug-bounty" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,11 +24,23 @@ resource "github_issue_label" "tts-tech-portfolio-private" {
   color      = each.value
 }
 
+module "tts-tech-portfolio-private" {
+  source = "./repo"
+
+  repo = "tts-tech-portfolio-private"
+}
+
 resource "github_issue_label" "ghad" {
   repository = "ghad"
   for_each   = var.issue_labels
   name       = each.key
   color      = each.value
+}
+
+module "ghad" {
+  source = "./repo"
+
+  repo = "ghad"
 }
 
 resource "github_issue_label" "laptop" {
@@ -58,11 +70,23 @@ resource "github_issue_label" "bug-bounty" {
   color      = each.value
 }
 
+module "bug-bounty" {
+  source = "./repo"
+
+  repo = "bug-bounty"
+}
+
 resource "github_issue_label" "before-you-ship" {
   repository = "before-you-ship"
   for_each   = var.issue_labels
   name       = each.key
   color      = each.value
+}
+
+module "before-you-ship" {
+  source = "./repo"
+
+  repo = "before-you-ship"
 }
 
 resource "github_issue_label" "dns" {
@@ -77,6 +101,12 @@ resource "github_issue_label" "vulnerability-disclosure-policy" {
   for_each   = var.issue_labels
   name       = each.key
   color      = each.value
+}
+
+module "vulnerability-disclosure-policy" {
+  source = "./repo"
+
+  repo = "vulnerability-disclosure-policy"
 }
 
 resource "github_issue_label" "handbook" {

--- a/terraform/repo/main.tf
+++ b/terraform/repo/main.tf
@@ -1,0 +1,7 @@
+resource "github_repository_file" "issue_templates" {
+  for_each = toset(var.issue_templates)
+
+  repository = var.repo
+  file       = ".github/ISSUE_TEMPLATE/${each.key}"
+  content    = file("${path.module}/../../.github/ISSUE_TEMPLATE/${each.key}")
+}

--- a/terraform/repo/vars.tf
+++ b/terraform/repo/vars.tf
@@ -1,0 +1,8 @@
+variable "repo" {
+  type = string
+}
+
+variable "issue_templates" {
+  type    = list(string)
+  default = ["general.md"]
+}


### PR DESCRIPTION
Was going to add an issue in aws-admin, and noticed that we didn't have the issue template in there. This pull request adds [the `general` template](https://github.com/18F/tts-tech-portfolio/blob/master/.github/ISSUE_TEMPLATE/general.md) to _most_ of our repositories; left out a few more shared repositories like DNS and the Handbook where it didn't quite feel appropriate. No strong feelings though.

I haven't `apply`d it yet—will do so once merged.