### PR TITLE
Create googlegroups.md

### DIFF
--- a/how_we_work/communicaion/googlegroups.md
+++ b/how_we_work/communicaion/googlegroups.md
@@ -1,6 +1,4 @@
 ## TTS Tech Portfolio
 ### Google Groups
 
-- [ ] [`TTS Technology Portfolio`](https://groups.google.com/a/gsa.gov/forum/#!forum/devops) - 
-- [ ] [`TTS Vulnerability Reports`](https://groups.google.com/a/gsa.gov/forum/#!forum/tts-vulnerability-reports) - 
-- [ ] [`TTS Software`](https://groups.google.com/a/gsa.gov/forum/#!forum/tts-vulnerability-reports) - 
+- See the [Google Groups](https://github.com/18F/tts-tech-portfolio/blob/master/how_we_work/ops_rotation.md#google-groups) in the OpsRotation Playbook 

--- a/how_we_work/communicaion/googlegroups.md
+++ b/how_we_work/communicaion/googlegroups.md
@@ -1,0 +1,6 @@
+## TTS Tech Portfolio
+### Google Groups
+
+- [ ] [`TTS Technology Portfolio`](https://groups.google.com/a/gsa.gov/forum/#!forum/devops) - 
+- [ ] [`TTS Vulnerability Reports`](https://groups.google.com/a/gsa.gov/forum/#!forum/tts-vulnerability-reports) - 
+- [ ] [`TTS Software`](https://groups.google.com/a/gsa.gov/forum/#!forum/tts-vulnerability-reports) - 


### PR DESCRIPTION
The OpsRotation checklist references responding to google groups and directs to - [ ] [Google Groups](https://github.com/18F/tts-tech-portfolio/blob/master/Operations%20Rotation%20-%20Playbook.md#google-groups)
 but the file directs to a broken link. 

Once this pull request is merged we can update the OpsRotation checklist