### PR TITLE
switch the Digital Council responsibility from Alyssa to Aidan

### DIFF
--- a/how_we_work/roles.md
+++ b/how_we_work/roles.md
@@ -5,7 +5,7 @@
 | [Contracting Officer Representative (COR)](https://docs.google.com/document/d/14xOFvIGwlG0Gbd52o1D4AyJ52RqzHpX91nfEYJKu5qQ/edit) for TTS-wide software/infrastructure purchases | --- | --- | X |
 | Cybersecurity Authorizing Official | X | --- | --- |
 | Cybersecurity Authorizing Official backup | --- | X | --- |
-| [Digital Council](https://docs.google.com/document/d/1v_kidGvpfVsMze-hJdaApI61Q3Vr6E-zZ5t79drnqIM/edit) member | --- | X | --- |
+| [Digital Council](https://docs.google.com/document/d/1v_kidGvpfVsMze-hJdaApI61Q3Vr6E-zZ5t79drnqIM/edit) member | X | --- | --- |
 | [DotGov points of contact](https://home.dotgov.gov/management/#points-of-contact) | X | --- | --- |
 | [FAS Systems Governance Committee (FSGC)](https://sites.google.com/a/gsa.gov/fas-systems-governance/home) representative | X | --- | --- |
 | [Infrastructure-as-a-Service (IaaS)](https://before-you-ship.18f.gov/infrastructure/) | --- | --- | X |


### PR DESCRIPTION
I've been doing a lot of Digital Council work anyway, and it closely aligns with my ownership of [the Enterprise Architecture Initiative](https://github.com/18F/tts-tech-portfolio/issues/636).

Already discussed with @its-a-lisa-at-work, so just formalizing the change. Kudos to her for pointing out that it would make sense.