### PR TITLE
add cybersecurity initiative

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -30,7 +30,7 @@ locals {
     "laptop" : { skip_issue_templates = true },
     "newrelic-terraform" : {},
     "raktabija" : { archived = true },
-    "slack-export-handling" : { archived = true },
+    "slack-export-handling" : {},
     "tts-tech-portfolio-private" : {},
     "tts-tech-portfolio" : {},
     "uswds-jekyll" : {},

--- a/terraform/repo/vars.tf
+++ b/terraform/repo/vars.tf
@@ -16,6 +16,7 @@ variable "issue_labels" {
     "g: initial"                    = "662E9B"
     "i: acquisition"                = "6ecbdb"
     "i: bug bounty"                 = "6ecbdb"
+    "i: cybersecurity"              = "6ecbdb"
     "i: DEI"                        = "6ecbdb"
     "i: Digital Council"            = "6ecbdb"
     "i: enterprise architecture"    = "6ecbdb"


### PR DESCRIPTION
Seeing enough work that doesn't have a clear home in another initiative; better to carve it out explicitly. Sorry for flip-flopping on this!