### PR TITLE
find Slack channels with a lot of single-channel guests

### DIFF
--- a/inspector/guests.js
+++ b/inspector/guests.js
@@ -1,30 +1,38 @@
-const { botClient } = require("./slack");
+const sortBy = require("lodash.sortby");
+const { paginate } = require("./slack");
 
 const getGuestIDs = async () => {
   const guestIDs = new Set();
-  for await (const usersPage of botClient.paginate("users.list")) {
-    for (const user of usersPage.members) {
-      // a.k.a. single-channel guest
-      if (user.is_ultra_restricted) {
-        guestIDs.add(user.id);
-      }
+  for await (const user of paginate("users.list", "members")) {
+    // a.k.a. single-channel guest
+    if (user.is_ultra_restricted) {
+      guestIDs.add(user.id);
     }
   }
   return guestIDs;
 };
 
+async function* getPublicChannels() {
+  const channels = paginate("conversations.list", "channels", {
+    exclude_archived: true,
+    types: "public_channel",
+  });
+
+  for await (const channel of channels) {
+    yield channel;
+  }
+}
+
 const getNumGuests = async (channelID, allGuestIDs) => {
   let numGuests = 0;
 
-  const memberPages = botClient.paginate("conversations.members", {
+  const memberIDs = paginate("conversations.members", "members", {
     channel: channelID,
   });
 
-  for await (const memberPage of memberPages) {
-    for (const memberID of memberPage.members) {
-      if (allGuestIDs.has(memberID)) {
-        numGuests += 1;
-      }
+  for await (const memberID of memberIDs) {
+    if (allGuestIDs.has(memberID)) {
+      numGuests += 1;
     }
   }
 
@@ -35,37 +43,40 @@ const getChannelInfo = async () => {
   const guestIDs = await getGuestIDs();
   const channels = [];
 
-  const conversationPages = botClient.paginate("conversations.list", {
-    exclude_archived: true,
-    types: "public_channel",
-  });
+  for await (const channel of getPublicChannels()) {
+    let numGuests;
 
-  for await (const conversationPage of conversationPages) {
-    for (const channel of conversationPage.channels) {
-      let numGuests;
+    try {
+      numGuests = await getNumGuests(channel.id, guestIDs);
+    } catch (err) {
+      console.error(`Failed to fetch members for ${channel.name}`);
+      // console.error(err);
+    }
 
-      try {
-        numGuests = await getNumGuests(channel.id, guestIDs);
-      } catch (err) {
-        console.error(`Failed to fetch members for ${channel.name}`);
-        // console.error(err);
-      }
-
-      if (numGuests > 0) {
-        channels.push({
-          name: channel.name,
-          num_guests: numGuests,
-        });
-      }
+    if (numGuests > 0) {
+      channels.push({
+        name: channel.name,
+        num_guests: numGuests,
+      });
     }
   }
 
   return channels;
 };
 
-(async () => {
+const run = async () => {
   const channels = await getChannelInfo();
   sortBy(channels, ["num_guests"]).forEach((channel) =>
     console.log(channel.name, channel.num_guests)
   );
-})();
+};
+
+// https://nodejs.org/docs/latest/api/modules.html#modules_accessing_the_main_module
+if (require.main === module) {
+  run();
+} else {
+  module.exports = {
+    getGuestIDs,
+    getPublicChannels,
+  };
+}

--- a/inspector/guests.js
+++ b/inspector/guests.js
@@ -1,13 +1,8 @@
-require("dotenv").config();
-
-const sortBy = require("lodash.sortby");
-const { WebClient } = require("@slack/web-api");
-
-const web = new WebClient(process.env.SLACK_BOT_TOKEN);
+const { botClient } = require("./slack");
 
 const getGuestIDs = async () => {
   const guestIDs = new Set();
-  for await (const usersPage of web.paginate("users.list")) {
+  for await (const usersPage of botClient.paginate("users.list")) {
     for (const user of usersPage.members) {
       // a.k.a. single-channel guest
       if (user.is_ultra_restricted) {
@@ -21,7 +16,7 @@ const getGuestIDs = async () => {
 const getNumGuests = async (channelID, allGuestIDs) => {
   let numGuests = 0;
 
-  const memberPages = web.paginate("conversations.members", {
+  const memberPages = botClient.paginate("conversations.members", {
     channel: channelID,
   });
 
@@ -40,7 +35,7 @@ const getChannelInfo = async () => {
   const guestIDs = await getGuestIDs();
   const channels = [];
 
-  const conversationPages = web.paginate("conversations.list", {
+  const conversationPages = botClient.paginate("conversations.list", {
     exclude_archived: true,
     types: "public_channel",
   });

--- a/inspector/guests.js
+++ b/inspector/guests.js
@@ -36,7 +36,7 @@ const getNumGuests = async (channelID, allGuestIDs) => {
   return numGuests;
 };
 
-(async () => {
+const getChannelInfo = async () => {
   const guestIDs = await getGuestIDs();
   const channels = [];
 
@@ -65,6 +65,11 @@ const getNumGuests = async (channelID, allGuestIDs) => {
     }
   }
 
+  return channels;
+};
+
+(async () => {
+  const channels = await getChannelInfo();
   sortBy(channels, ["num_guests"]).forEach((channel) =>
     console.log(channel.name, channel.num_guests)
   );

--- a/inspector/guests.js
+++ b/inspector/guests.js
@@ -1,0 +1,28 @@
+require("dotenv").config();
+
+const { WebClient } = require("@slack/web-api");
+
+const web = new WebClient(process.env.SLACK_BOT_TOKEN);
+
+(async () => {
+  const conversationPages = web.paginate("conversations.list", {
+    exclude_archived: true,
+    types: "public_channel",
+  });
+
+  for await (const conversationPage of conversationPages) {
+    for (const channel of conversationPage.channels) {
+      console.log(channel.name);
+
+      const memberPages = web.paginate("conversations.members", {
+        channel: channel.id,
+      });
+
+      for await (const memberPage of memberPages) {
+        for (const memberID of memberPage.members) {
+          console.log(memberID);
+        }
+      }
+    }
+  }
+})();

--- a/inspector/guests.js
+++ b/inspector/guests.js
@@ -5,6 +5,16 @@ const { WebClient } = require("@slack/web-api");
 const web = new WebClient(process.env.SLACK_BOT_TOKEN);
 
 (async () => {
+  const guestIDs = new Set();
+  for await (const usersPage of web.paginate("users.list")) {
+    for (const user of usersPage.members) {
+      // a.k.a. single-channel guest
+      if (user.is_ultra_restricted) {
+        guestIDs.add(user.id);
+      }
+    }
+  }
+
   const conversationPages = web.paginate("conversations.list", {
     exclude_archived: true,
     types: "public_channel",
@@ -12,16 +22,27 @@ const web = new WebClient(process.env.SLACK_BOT_TOKEN);
 
   for await (const conversationPage of conversationPages) {
     for (const channel of conversationPage.channels) {
-      console.log(channel.name);
+      let numGuests = 0;
 
       const memberPages = web.paginate("conversations.members", {
         channel: channel.id,
       });
 
-      for await (const memberPage of memberPages) {
-        for (const memberID of memberPage.members) {
-          console.log(memberID);
+      try {
+        for await (const memberPage of memberPages) {
+          for (const memberID of memberPage.members) {
+            if (guestIDs.has(memberID)) {
+              numGuests += 1;
+            }
+          }
         }
+      } catch (err) {
+        console.error(`Failed to fetch members for ${channel.name}`);
+        console.error(err);
+      }
+
+      if (numGuests > 0) {
+        console.log(channel.name, numGuests);
       }
     }
   }

--- a/inspector/package-lock.json
+++ b/inspector/package-lock.json
@@ -3135,8 +3135,7 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "make-dir": {
       "version": "3.1.0",

--- a/inspector/package.json
+++ b/inspector/package.json
@@ -7,7 +7,8 @@
     "@octokit/graphql": "^4.5.6",
     "@slack/web-api": "^5.11.0",
     "dotenv": "^8.2.0",
-    "lodash.countby": "^4.6.0"
+    "lodash.countby": "^4.6.0",
+    "lodash.sortby": "^4.7.0"
   },
   "devDependencies": {
     "jest": "^26.4.2",

--- a/inspector/pr-nudges.js
+++ b/inspector/pr-nudges.js
@@ -4,11 +4,10 @@ const countBy = require("lodash.countby");
 const fs = require("fs");
 const path = require("path");
 const { graphql } = require("@octokit/graphql");
-const { WebClient } = require("@slack/web-api");
+const slack = require("./slack");
 
-// both are needed, since search is only possible with a user token (https://api.slack.com/methods/search.messages#facts) but we want messages to come from the bot
-const slackUserClient = new WebClient(process.env.SLACK_USER_TOKEN);
-const slackBotClient = new WebClient(process.env.SLACK_BOT_TOKEN);
+const slackUserClient = slack.userClient;
+const slackBotClient = slack.botClient;
 
 const queryPath = path.join(__dirname, "repos.graphql");
 const repoQuery = fs.readFileSync(queryPath, "utf8");

--- a/inspector/slack.js
+++ b/inspector/slack.js
@@ -1,0 +1,9 @@
+require("dotenv").config();
+
+const { WebClient } = require("@slack/web-api");
+
+// both are needed, since search is only possible with a user token (https://api.slack.com/methods/search.messages#facts) but we want messages to come from the bot
+module.exports = {
+  userClient: new WebClient(process.env.SLACK_USER_TOKEN),
+  botClient: new WebClient(process.env.SLACK_BOT_TOKEN),
+};

--- a/inspector/slack.js
+++ b/inspector/slack.js
@@ -3,7 +3,22 @@ require("dotenv").config();
 const { WebClient } = require("@slack/web-api");
 
 // both are needed, since search is only possible with a user token (https://api.slack.com/methods/search.messages#facts) but we want messages to come from the bot
+const userClient = new WebClient(process.env.SLACK_USER_TOKEN);
+const botClient = new WebClient(process.env.SLACK_BOT_TOKEN);
+
+const paginate = async function* paginate(method, key, options) {
+  options = options || {};
+  const pages = botClient.paginate(method, options);
+
+  for await (const page of pages) {
+    for (const item of page[key]) {
+      yield item;
+    }
+  }
+};
+
 module.exports = {
-  userClient: new WebClient(process.env.SLACK_USER_TOKEN),
-  botClient: new WebClient(process.env.SLACK_BOT_TOKEN),
+  userClient,
+  botClient,
+  paginate,
 };


### PR DESCRIPTION
We didn't get a lot of uptake on https://github.com/18F/tts-tech-portfolio/issues/122, so wanted to find channels that I could nudge. This adds a script to print out channels and their number of single-channel guests.

<details>
<summary>The output, after I did some manual archiving of channels that were stale</summary>
<pre><code>opensource 1
admins-slack 1
c-data 1
incident-response 1
call-center-listen-in 1
wg-govcareer 1
login-devops 1
calc 1
search 1
tmf-partners 1
api 1
gsa-cloud-partners 1
login-security 1
dtmo-partners 1
search-design 1
feedback-analytics 1
tts-oa 1
usda-coe-cloud 1
code-gov-team 1
usmc-partners 1
opm-ux-partners 1
sec_intake_partners 1
login-acuant-external 1
doj-crt-km-partners 1
covid-screener 1
identity-give 1
hs-vendors-ohs-tta 1
pif-partner-va_cto 1
rrb-modernization-partners 1
sf 2
g-accessibility 2
nrrd-partners 2
vet-employment-center 2
cps-caer-partners 2
jackson-hole 2
opm-faces-partners 2
partners-hs-oversight 2
arl-partners 2
partners-hs-ohs-eclkc 2
doj-crt-ada-gov-partners 2
gsait-shared 2
townhall 3
federalist-support 3
datagov-devsecops 3
login-compliance 3
fs-of-partners 3
login-lexis-external 3
g-research 4
login-user-support 4
centers-of-excellence 4
datagov-ckan-multi 4
partners-texas-10x-agile-budgeting 4
partners-doi-usgs-water-area-platform-modernization 4
pifs 5
bug-bounty-partners 5
10x-agile-budgeting-partners 5
chicago-public 5
10x-coil 5
partners-cms-eapd 7
doj-crt-partners 8
cxcap-strategy-partners 9
login-partners-sam 10
state-ops-all-partners 10
challenge-gov-partners 10
identity-public 12
partners-cms-macpro 13
10x-public 18
code-gov-partners 20
fedramp-partners 22
eregs-public 23
nyc-public 26
sf-public 38
federalist-public 45
opensource-public 95
devops-public 212
alumni 261
login-partner-support 530
uswds-public 896
</code></pre>
</details>