### PR TITLE
add OpsRotation task of ensuring project boards are populated

### DIFF
--- a/.github/ISSUE_TEMPLATE/ops.md
+++ b/.github/ISSUE_TEMPLATE/ops.md
@@ -10,6 +10,9 @@ Each of the following should be done within the dates above. See the [playbook](
 
 ## GitHub
 
+- [ ] [Add issues from linked repositories to our project boards](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/adding-issues-and-pull-requests-to-a-project-board)
+   - [ ] [Issues](https://github.com/orgs/18F/projects/11?fullscreen=true)
+   - [ ] [Pull requests](https://github.com/orgs/18F/projects/19?fullscreen=true)
 - [ ] Review and ideally merge (or close) open [pull requests to Tech Portfolio repositories](https://github.com/orgs/18F/projects/19?fullscreen=true)
 - [ ] [Update the public IT Standards dataset](https://github.com/GSA/data/tree/master/enterprise-architecture#updating-the-list)
 - [ ] [Run the Inspector](https://github.com/18F/tts-tech-portfolio/tree/master/inspector#usage)


### PR DESCRIPTION
Easy to miss issues and pull requests otherwise.