### PR TITLE
Seeking clarity on pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/ops.md
+++ b/.github/ISSUE_TEMPLATE/ops.md
@@ -12,7 +12,7 @@ Each of the following should be done within the dates above. See the [playbook](
 
 - [ ] [Add issues from linked repositories to our project boards](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/adding-issues-and-pull-requests-to-a-project-board)
    - [ ] [Issues](https://github.com/orgs/18F/projects/11?fullscreen=true)
-   - [ ] [Pull requests](https://github.com/orgs/18F/projects/19?fullscreen=true)
+   - [ ] [Pull requests](https://github.com/orgs/18F/projects/19?fullscreen=true)(ignore the DNS pull requests)
 - [ ] Review and ideally merge (or close) open [pull requests to Tech Portfolio repositories](https://github.com/orgs/18F/projects/19?fullscreen=true)
 - [ ] [Update the public IT Standards dataset](https://github.com/GSA/data/tree/master/enterprise-architecture#updating-the-list)
 - [ ] [Run the Inspector](https://github.com/18F/tts-tech-portfolio/tree/master/inspector#usage)


### PR DESCRIPTION
DNS pull requests seem like they are beyond the scope of OpsRotation and should be handled by someone with the appropriate knowledge, skills and abilities. I added a note to let future OpsRotation folks know that those pull requests that are in the board do not have to be reviewed as a part of OpsRotation.