### PR TITLE
Removed redundancies

### DIFF
--- a/.github/ISSUE_TEMPLATE/ops.md
+++ b/.github/ISSUE_TEMPLATE/ops.md
@@ -13,7 +13,6 @@ Each of the following should be done within the dates above. See the [playbook](
 - [ ] [Add issues from linked repositories to our project boards](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/adding-issues-and-pull-requests-to-a-project-board)
    - [ ] [Issues](https://github.com/orgs/18F/projects/11?fullscreen=true)
    - [ ] [Pull requests](https://github.com/orgs/18F/projects/19?fullscreen=true)
-- [ ] Review and ideally merge (or close) open [pull requests to Tech Portfolio repositories](https://github.com/orgs/18F/projects/19?fullscreen=true)
 - [ ] [Update the public IT Standards dataset](https://github.com/GSA/data/tree/master/enterprise-architecture#updating-the-list)
 - [ ] [Run the Inspector](https://github.com/18F/tts-tech-portfolio/tree/master/inspector#usage)
 


### PR DESCRIPTION
There were two separate lines about pull requests; since the Tech Portfolio Pull Requests are included in the Pull Request project board, I don't see a need to have that as a separate line item