### PR TITLE
remove reference to the cloud.gov SSP template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ato.md
+++ b/.github/ISSUE_TEMPLATE/ato.md
@@ -35,7 +35,6 @@ Everything in this section needs to be completed before the project will be sche
     - Search [this page](https://insite.gsa.gov/portal/content/627238) for "Rules of Engagement (RoE) 90-Day LATO Penetration Test TEMPLATE", even if this isn't for a 90-day LATO.
     - [System/network diagram tips](https://before-you-ship.18f.gov/ato/ssp/#diagrams)
   - [ ] Add [System Security Plan (SSP)](https://before-you-ship.18f.gov/ato/ssp/) template
-    - For Low systems on cloud.gov, use [this template](https://docs.google.com/a/gsa.gov/document/d/1tVbH39TFfvSaBbjWfLaR3GLOuvsLuhLFJ75xKowEV5c/edit?usp=sharing)
     - For a 90-day ATO, delete Section 13.
 - [ ] Make a copy of the [ATO Sprinting notes template](https://docs.google.com/document/d/1EdcNyE1kkQve3tHyiV1QIRWNOBlTeh33lAbX0h4h18M/edit) and save it in the [Sprinting Team folder](https://drive.google.com/drive/folders/0B2tmNhXsZ-EyVkVra21NTmc0U00?usp=sharing) with a title of `ATO Sprinting Team notes - <project>`.
   - [ ] Fill out the placeholders.


### PR DESCRIPTION
The template is now out of date. Security may bring it up to date, but at @jhoyt22's request, we'll stop pointing to it in the meantime.