### PR TITLE
remove some labels that are no longer in use

### DIFF
--- a/how_we_work/workflow.md
+++ b/how_we_work/workflow.md
@@ -218,8 +218,6 @@ If there is a repository that the issue is specifically applicable to, create it
 
 We have a couple set types of labels. Beyond those, you are also welcome to add whatever labels are useful to you. The labels are [configured as code](terraform/).
 
-In order to allow for continued asynchronous work as much as possible, if a person needs feedback on an issue, use the label `feedback needed` and tag in the person and provide a synopsis of what feedback you're looking for.
-
 #### [Grooming status](https://github.com/18F/tts-tech-portfolio/labels?q=groom)
 
 **Purpose:** Indicate the state of the issue itself.

--- a/terraform/repo/vars.tf
+++ b/terraform/repo/vars.tf
@@ -4,12 +4,7 @@ variable "repo" {
 
 variable "issue_labels" {
   default = {
-    "a: blog-able"                  = "F72585"
-    "a: demo-able"                  = "F72585"
-    "dg: decide"                    = "662E9B"
-    "dg: delegate"                  = "662E9B"
     "e: aws cleanup"                = "6ecbdb"
-    "e: bb expansion"               = "6ecbdb"
     "e: SaaS documentation"         = "6ecbdb"
     "g: accepted"                   = "662E9B"
     "g: final"                      = "662E9B"
@@ -27,7 +22,6 @@ variable "issue_labels" {
     "i: misc"                       = "6ecbdb"
     "i: SaaS authorizations"        = "6ecbdb"
     "m: due date"                   = "EA3546"
-    "m: feedback needed"            = "F72585"
     "t: days"                       = "F86624"
     "t: expedite"                   = "F86624"
     "t: hours"                      = "F86624"


### PR DESCRIPTION
I'm not against having these labels, but they don't seem to be getting used, so proposing removal to reduce noise in the label list.

_Please wait for two Approvals before merging._