### PR TITLE
remove the vulnerability-disclosure-responsibilities file

### DIFF
--- a/how_we_work/roles.md
+++ b/how_we_work/roles.md
@@ -82,3 +82,4 @@ This person will regularly:
 - Coordinate on policy changes, etc. with:
   - TTS
   - The platform vendor
+- Manage the [response process](https://handbook.tts.gsa.gov/responding-to-public-disclosure-vulnerabilities/) within TTS

--- a/how_we_work/roles.md
+++ b/how_we_work/roles.md
@@ -1,28 +1,26 @@
 # Roles
 
 | Role                                                                                                                                                                            | Aidan | Alyssa | John | Melanie | Amit |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------ | ---- | ------- |------- |
-| [Contracting Officer Representative (COR)](https://docs.google.com/document/d/14xOFvIGwlG0Gbd52o1D4AyJ52RqzHpX91nfEYJKu5qQ/edit) for TTS-wide software/infrastructure purchases | ---   | ---    | X    | ---     | ---    |
-| Cybersecurity [Authorizing Official](#authorizing-official)                                                                                                                     | X     | ---    | ---  | ---     | ---    |
-| Cybersecurity Authorizing Official [backup](#authorizing-official)                                                                                                              | ---   | X      | ---  | ---     | ---    |
-| [Cybersecurity Advisor](#cybersecurity-advisor)                                                                                                                                 | ---   | X      | ---  | ---     | ---    |
-| [Digital Council](https://docs.google.com/document/d/1v_kidGvpfVsMze-hJdaApI61Q3Vr6E-zZ5t79drnqIM/edit) member                                                                  | X     | ---    | ---  | ---     | ---    |
-| [Director](#director)                                                                                                                                                           | X     | ---    | ---  | ---     | ---    |
-| [DotGov points of contact](https://home.dotgov.gov/management/#points-of-contact)                                                                                               | X     | ---    | ---  | ---     | ---    |
-| [FAS Systems Governance Committee (FSGC)](https://sites.google.com/a/gsa.gov/fas-systems-governance/home) representative                                                        | X     | ---    | ---  | ---     | ---    |
-| [Infrastructure-as-a-Service (IaaS)](https://before-you-ship.18f.gov/infrastructure/)                                                                                           | ---   | ---    | X    | ---     | X      |
-| Mac Working Group representative                                                                                                                                                | X     | ---    | ---  | ---     | ---    |
-| [Operations Rotation](ops_rotation.md) person                                                                                                                                   | X     | X      | X    | ---     | X      |
-| [P-Card](https://drive.google.com/drive/folders/1CkxpHq0mDFeAnXlaMQJ9RQOCioVHckgs) Approving Official                                                                           | X     | ---    | ---  | ---     | ---    |
-| [P-Card](https://drive.google.com/drive/folders/1CkxpHq0mDFeAnXlaMQJ9RQOCioVHckgs) Holder                                                                                       | ---   | ---    | X    | ---     | ---    |
-|  Software concierge [(Security Authorization)](#security-authorizations)                                                                                                        | ---   | X      | ---  | ---     | ---    |
-| Software concierge (acquisition)                                                                                                                                                | ---   | ---    | ---  | X       | ---    |
-| [Vulnerability Disclosure Lead](#vulnerability-disclosure-lead)                                                                                                                 | ---   | X      | ---  | ---     | ---    |
-| Vulnerability Disclosure [COR](https://docs.google.com/document/d/14xOFvIGwlG0Gbd52o1D4AyJ52RqzHpX91nfEYJKu5qQ/edit)                                                            | ---   | X      | ---  | ---     | ---    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------ | ---- | ------- | ---- |
+| [Contracting Officer Representative (COR)](https://docs.google.com/document/d/14xOFvIGwlG0Gbd52o1D4AyJ52RqzHpX91nfEYJKu5qQ/edit) for TTS-wide software/infrastructure purchases | ---   | ---    | X    | ---     | ---  |
+| Cybersecurity [Authorizing Official](#authorizing-official)                                                                                                                     | X     | ---    | ---  | ---     | ---  |
+| Cybersecurity Authorizing Official [backup](#authorizing-official)                                                                                                              | ---   | X      | ---  | ---     | ---  |
+| [Cybersecurity Advisor](#cybersecurity-advisor)                                                                                                                                 | ---   | X      | ---  | ---     | ---  |
+| [Digital Council](https://docs.google.com/document/d/1v_kidGvpfVsMze-hJdaApI61Q3Vr6E-zZ5t79drnqIM/edit) member                                                                  | X     | ---    | ---  | ---     | ---  |
+| [Director](#director)                                                                                                                                                           | X     | ---    | ---  | ---     | ---  |
+| [DotGov points of contact](https://home.dotgov.gov/management/#points-of-contact)                                                                                               | X     | ---    | ---  | ---     | ---  |
+| [FAS Systems Governance Committee (FSGC)](https://sites.google.com/a/gsa.gov/fas-systems-governance/home) representative                                                        | X     | ---    | ---  | ---     | ---  |
+| [Infrastructure-as-a-Service (IaaS)](https://before-you-ship.18f.gov/infrastructure/)                                                                                           | ---   | ---    | X    | ---     | X    |
+| Mac Working Group representative                                                                                                                                                | X     | ---    | ---  | ---     | ---  |
+| [Operations Rotation](ops_rotation.md) person                                                                                                                                   | X     | X      | X    | ---     | X    |
+| [P-Card](https://drive.google.com/drive/folders/1CkxpHq0mDFeAnXlaMQJ9RQOCioVHckgs) Approving Official                                                                           | X     | ---    | ---  | ---     | ---  |
+| [P-Card](https://drive.google.com/drive/folders/1CkxpHq0mDFeAnXlaMQJ9RQOCioVHckgs) Holder                                                                                       | ---   | ---    | X    | ---     | ---  |
+| Software concierge [(Security Authorization)](#security-authorizations)                                                                                                         | ---   | X      | ---  | ---     | ---  |
+| Software concierge (acquisition)                                                                                                                                                | ---   | ---    | ---  | X       | ---  |
+| [Vulnerability Disclosure Lead](#vulnerability-disclosure-lead)                                                                                                                 | ---   | X      | ---  | ---     | ---  |
+| Vulnerability Disclosure [COR](https://docs.google.com/document/d/14xOFvIGwlG0Gbd52o1D4AyJ52RqzHpX91nfEYJKu5qQ/edit)                                                            | ---   | X      | ---  | ---     | ---  |
 
 We also have [Initiative](workflow.md#structure) owners—see the `Initiatives` column of [the board](https://github.com/orgs/18F/projects/11?fullscreen=true).
-
-
 
 ## Authorizing Official
 
@@ -30,13 +28,14 @@ We also have [Initiative](workflow.md#structure) owners—see the `Initiatives` 
 - [Archer](https://before-you-ship.18f.gov/ato/archer/)
 
 ## Authorizing Official Backup
+
 - Support the TTS [Authorizing Official](#authorizing-official) in the tasks they need help with
-  - The AO Backup provides technical and organizational support to the Authorizing Official. 
-  - Has a working knowledge of system function, security policies, and technical security safeguards, and serve as technical advisor(s) to the Authorizing Official. 
+  - The AO Backup provides technical and organizational support to the Authorizing Official.
+  - Has a working knowledge of system function, security policies, and technical security safeguards, and serve as technical advisor(s) to the Authorizing Official.
 
 ## Cybersecurity Advisor
-- Advises executives on decisions and helps establishes vision and direction for an organization's cyber and cyber-related resources and/or operations.
 
+- Advises executives on decisions and helps establishes vision and direction for an organization's cyber and cyber-related resources and/or operations.
 
 ## Director
 
@@ -62,12 +61,13 @@ The Director does the following:
 - [Job post](https://join.tts.gsa.gov/join/technology-portfolio-director/)
 - [Leadership Roles & Responsibilities](https://docs.google.com/document/d/1B4rtZd06w7ITABrjrGWRjAfU4f-go2jnuO_D0PokJMw/edit#heading=h.5lx1f0htbp8v)
 
-## Software Concierge 
+## Software Concierge
 
 ### Security Authorizations
- - Works with GSA IT Security and Vendor to assure that the products that TTS uses remain authorized. 
- - This role is more focused on coordination to ensure that TTS user needs are met. 
- 
+
+- Works with GSA IT Security and Vendor to assure that the products that TTS uses remain authorized.
+- This role is more focused on coordination to ensure that TTS user needs are met.
+
 ## Vulnerability Disclosure Lead
 
 This person will regularly:

--- a/vulnerability-disclosure-responsibilities.md
+++ b/vulnerability-disclosure-responsibilities.md
@@ -1,7 +1,0 @@
-## Vulnerability Management
-
-### Vulnerability Disclosure Responisbilities
-
-**First Responder**
-
-- Set an email alert via Google Calendar at the 77-day (11 weeks) mark from the date the reporter sent the email, so that, if no response or resolution has yet been made, the team has about 2 weeks to bring the issue to resolution and close out the issue with the reporter.


### PR DESCRIPTION
Moving to the "Public disclosures of vulnerabilities" page in the Handbook: https://github.com/18F/handbook/pull/2287. Merge that pull request first.

Also formatted the roles file with Prettier. Easiest to [review ignoring whitespace](https://github.com/18F/tts-tech-portfolio/pull/1144/files?diff=unified&w=1).