### PR TITLE
shorten the custom software initiative description

### DIFF
--- a/terraform/repo/vars.tf
+++ b/terraform/repo/vars.tf
@@ -29,7 +29,7 @@ locals {
     # initiatives
     "i: custom software" = {
       color       = local.label_colors.initiatives
-      description = "Relating to systems we've built in TTS and their need for tools, guidance, security authorization, etc."
+      description = "Relating to systems built in TTS and their need for tools, guidance, security authorization, etc."
     }
     "i: customer support" = {
       color       = local.label_colors.initiatives

--- a/terraform/repo/vars.tf
+++ b/terraform/repo/vars.tf
@@ -29,6 +29,7 @@ locals {
     # initiatives
     "i: custom software" = {
       color       = local.label_colors.initiatives
+      # GH Label description is limited to 100 characters
       description = "Relating to systems built in TTS and their need for tools, guidance, security authorization, etc."
     }
     "i: customer support" = {


### PR DESCRIPTION
There's apparently a length limit of 100 characters. Already `apply`'d, to ensure it would work.