### PR TITLE
Update ops.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/ops.md
+++ b/.github/ISSUE_TEMPLATE/ops.md
@@ -11,7 +11,6 @@ Each of the following should be done within the dates above. See the [playbook](
 ## GitHub
 
 - [ ] [Add issues from linked repositories to our project boards](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/adding-issues-and-pull-requests-to-a-project-board)
-  - [ ] [Issues](https://github.com/orgs/18F/projects/11?fullscreen=true)
   - [ ] [Pull requests](https://github.com/orgs/18F/projects/19?fullscreen=true)
 - [ ] Review and ideally merge (or close) open [pull requests to Tech Portfolio repositories](https://github.com/orgs/18F/projects/19?fullscreen=true)
   - You don't need to merge everything yourself, but try and make sure everything gets merged (by pinging the relevant people, etc).


### PR DESCRIPTION
Remove adding Issues as a task for Ops Rotation. Folks should be adding new issues to the board when they create it, it's unclear what Ops Rotation role is here.