### PR TITLE
Remove the issue template from .github

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,7 +22,7 @@ provider "github" {
 locals {
   # options default to false
   repos = {
-    ".github" : {},
+    ".github" : { shared_content_ownership = true },
     "aws-admin" : {},
     "aws-admin-cleanup" : {},
     "before-you-ship" : { archived = true },


### PR DESCRIPTION
All 18F repos without their own issue templates are inheriting this one.

https://gsa-tts.slack.com/archives/C02KXM98G/p1625693834010800