### PR TITLE
Update README.md to match main.tf

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,6 @@
 ## Requirements
 
-- Terraform v0.14 (we recommend [tfenv](https://github.com/tfutils/tfenv))
+- Terraform v1.0 (we recommend [tfenv](https://github.com/tfutils/tfenv))
 
 
 ## Development

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,6 @@
 ## Requirements
 
-- Terraform v1.0 (we recommend [tfenv](https://github.com/tfutils/tfenv))
+See [`required_version` of Terraform](main.tf). We recommend [tfenv](https://github.com/tfutils/tfenv) for managing Terraform versions.
 
 
 ## Development


### PR DESCRIPTION
Line 2 of main.tf asserts that version 1.x of Terraform must be used:

```
required_version = "~> 1.0"
``` 

https://github.com/18F/tts-tech-portfolio/blob/main/terraform/main.tf#L2

Per the Terraform version control documentation: 

```
~>: Allows only the rightmost version component to increment. 
```

Additional documentation is available on Terraform's website: https://www.terraform.io/docs/language/expressions/version-constraints.html#gt--1