### PR TITLE
add Tech Portfolio members to GitHub organizations via code

### DIFF
--- a/.github/ISSUE_TEMPLATE/github-org.md
+++ b/.github/ISSUE_TEMPLATE/github-org.md
@@ -15,9 +15,9 @@ assignees: ""
 1. [ ] [Submit a micropurchase request](https://handbook.tts.gsa.gov/purchase-requests/) if you need private repositories.
 1. [ ] [Create the organization.](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/creating-a-new-organization-from-scratch)
 1. [ ] [Enforce two-factor authentication.](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/requiring-two-factor-authentication-in-your-organization)
+1. [ ] Add to the [list of organizations in Terraform](https://github.com/18F/tts-tech-portfolio/blob/main/terraform/orgs.tf)
 1. [ ] [Add users.](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/inviting-users-to-join-your-organization)
-   - [ ] Add @18F/tts-tech-portfolio members and @tts-bot as Owners so we can do offboarding and other admin-y things.
 1. [ ] Ensure that all your webhooks, integrations, etc. are in place.
 1. [ ] [Transfer repositories.](https://help.github.com/en/github/administering-a-repository/transferring-a-repository)
        — GitHub does redirects, but you'll want to make sure it doesn't break things like deployment.
-1. [ ] Add to the [list of organizations](https://handbook.tts.gsa.gov/github/#organizations).
+1. [ ] Add to the [list of organizations in the Handbook](https://handbook.tts.gsa.gov/github/#organizations).

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/github" {
+  version = "4.12.2"
+  hashes = [
+    "h1:xIw9ntB7jnXgJyLuouTg6LTG3rymizplREJ/BqApeQg=",
+    "zh:1037e5f1697a78f6fc0cb410d3af8718b3d041a991fa3d46276e442928d3e512",
+    "zh:234d50e29f275d54df2df0859b249c300c6b19c0849c3482accc9c37f216e10e",
+    "zh:2f8cd3c6f95a39ffc095c3bd529f80fe8aade394a0d33febd226bfaa899afe72",
+    "zh:3c1d2b3ae22994fb3353823e009139c4291265a65c3b0ad10cfb8eb6bc74f3c0",
+    "zh:441ecd217ceb7bad5e70afc5972c1815271addcb006d356f2aee4e34de8a5fb1",
+    "zh:4b03978ce6d27b9bfbf739187e048b08104318121eebb4cd156bd2d3a08fb313",
+    "zh:730a32922c4e51dfc99497e1bbdb0e87a76156342c09f30991586d832653a5c0",
+    "zh:9cc9abc09c185665d6459ebd2bd31a7b97016ea8ee6eac8be5d630ceabcb1df3",
+    "zh:a72b190c7f7edc5daaf74ae4c1c0c55911e94e7a3da0c4c49502b019e7ee9dbd",
+    "zh:b72764f35fda819fea58a5f7ec90b8531d6badcae78f8eff405a28bb64fe7ef2",
+    "zh:c6cc74e970f3d2bc3e5f16e86590bdbab7103066abe917dbaf2b7c89c869503b",
+    "zh:d6b0e856a5c1eb3ffdbfde5084e6641d01585b72faecf2d5ae51928f64ce5bf9",
+    "zh:f500897730f3bc0614f22dbf73634c4245d7fcf912fc12df4d67c0ebf34cf7fc",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.1.0"
   hashes = [

--- a/terraform/org/main.tf
+++ b/terraform/org/main.tf
@@ -1,0 +1,28 @@
+provider "github" {
+  owner = "18F"
+  alias = "source"
+}
+
+provider "github" {
+  owner = var.org
+  alias = "dest"
+}
+
+data "github_team" "tech_portfolio" {
+  provider = github.source
+  slug     = "tts-tech-portfolio"
+}
+
+resource "github_membership" "owner" {
+  for_each = toset(data.github_team.tech_portfolio.members)
+
+  provider = github.dest
+  username = each.key
+  role     = "admin"
+}
+
+resource "github_membership" "tts_bot" {
+  provider = github.dest
+  username = "tts-bot"
+  role     = "admin"
+}

--- a/terraform/org/main.tf
+++ b/terraform/org/main.tf
@@ -13,16 +13,14 @@ data "github_team" "tech_portfolio" {
   slug     = "tts-tech-portfolio"
 }
 
+locals {
+  owners = concat(data.github_team.tech_portfolio.members, ["tts-bot"])
+}
+
 resource "github_membership" "owner" {
-  for_each = toset(data.github_team.tech_portfolio.members)
+  for_each = toset(local.owners)
 
   provider = github.dest
   username = each.key
-  role     = "admin"
-}
-
-resource "github_membership" "tts_bot" {
-  provider = github.dest
-  username = "tts-bot"
   role     = "admin"
 }

--- a/terraform/org/vars.tf
+++ b/terraform/org/vars.tf
@@ -1,0 +1,1 @@
+variable "org" {}

--- a/terraform/orgs.tf
+++ b/terraform/orgs.tf
@@ -1,0 +1,4 @@
+module "org_18f" {
+  source = "./org"
+  org    = "18F"
+}

--- a/terraform/orgs.tf
+++ b/terraform/orgs.tf
@@ -1,4 +1,60 @@
+# all TTS-managed orgs in
+# https://handbook.tts.gsa.gov/github/#organizations
+#
+# Unable to use a loop, because "A module containing its own provider configurations is not compatible with the for_each … arguments"
+# https://www.terraform.io/docs/language/modules/develop/providers.html
+
 module "org_18f" {
   source = "./org"
   org    = "18F"
+}
+
+module "cloud_gov" {
+  source = "./org"
+  org    = "cloud_gov"
+}
+
+module "digital_analytics_program" {
+  source = "./org"
+  org    = "digital_analytics_program"
+}
+
+module "digitalgov" {
+  source = "./org"
+  org    = "digitalgov"
+}
+
+module "federalist_users" {
+  source = "./org"
+  org    = "federalist_users"
+}
+
+module "fedramp" {
+  source = "./org"
+  org    = "fedramp"
+}
+
+module "fellows_in_innovation" {
+  source = "./org"
+  org    = "fellows_in_innovation"
+}
+
+module "project_open_data" {
+  source = "./org"
+  org    = "project_open_data"
+}
+
+module "presidential_innovation_fellows" {
+  source = "./org"
+  org    = "presidential_innovation_fellows"
+}
+
+module "usagov" {
+  source = "./org"
+  org    = "usagov"
+}
+
+module "uswds" {
+  source = "./org"
+  org    = "uswds"
 }


### PR DESCRIPTION
Closes https://github.com/18F/tts-tech-portfolio/issues/83.

Questions:

- Something going wrong with the `apply` could remove all of us from the orgs. Are we ok with that risk?
- The source list of usernames is the @18F/tts-tech-portfolio team. Should we keep it that way, or flip it around so that team is created via code? (Could happen in a separate pull request.)