### PR TITLE
automatically push re-generated github.md file

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -26,3 +26,10 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         env:
           GITHUB_TOKEN: "${{ secrets.GH_SECRET_TOKEN }}"
+
+      - name: push changes
+        uses: EndBug/add-and-commit@v7 # You can change this to use a specific version
+        with:
+          add: how_we_work/github.md
+          message: (automatically) re-generate the GitHub documentation
+          push: true


### PR DESCRIPTION
`github.md` is being regenerated by the `terraform apply` within GitHub Actions, but the change wasn't making it into the repository, causing the same `plan` to show up every time. Example in https://github.com/18F/tts-tech-portfolio/pull/1463#issuecomment-883757359.

Once merged, this should create clean `plan`s going forward.