### PR TITLE
remove outdated software management info

### DIFF
--- a/how_we_work/internal_links.md
+++ b/how_we_work/internal_links.md
@@ -65,6 +65,7 @@ See [shared credential info](standards.md).
 
 - [HRLinks Roster](https://docs.google.com/spreadsheets/d/1tRzGxnI1E4soOkHsod5xd-XmO33cy0cKRx7LpSNAaF0/edit?usp=sharing)
 - [Talent Database](https://docs.google.com/spreadsheets/d/16x18nV5jHwsBzw12b32PDxV6zQtFkzbaGV6W2uNhaUY/edit#gid=361159397)
+- [Org chart pivot table](https://docs.google.com/spreadsheets/d/1hp8Xw2qbW9SUdahRFKr6I2pAcsg1LrxwD9HxDxfppcg/edit#gid=1627662065)
 - [GSA Separations (people who've left GSA)](https://d2d.gsa.gov/dataset/gsa-separations)
 
 ## IaaS Management

--- a/how_we_work/internal_links.md
+++ b/how_we_work/internal_links.md
@@ -8,7 +8,8 @@ Access to many of these are restricted.
 - [Presentations/decks/slides about the team](https://drive.google.com/drive/folders/10LCPsg-ENLbqO_xEXPsbx81vTZc36iIX?usp=sharing)
 
 ## Credentials
-The Tech Portfolio tightly manages shared credentials using [Google Team Drive](https://drive.google.com/drive/u/0/folders/1B0INOeCQQAv5eDBaoM4rgtaNkU9S6zDs), keepassxc databases are stored and synced using Google Drive Filestream (both can be installed from the GSA Self Service App). 
+
+See [shared credential info](standards.md).
 
 ## Money
 
@@ -59,18 +60,6 @@ The Tech Portfolio tightly manages shared credentials using [Google Team Drive](
 - [OA Post-Award Trello Board](https://trello.com/b/E6jsnfRZ/tts-oa-post-award-management)
   - Where our existing SaaS buys are tracked.
 - [Software available for Mac](https://docs.google.com/document/d/1RFxxEC52UD-pnWVYGertD6zx6YJDFrOog5AMjjGA1hU/edit)
-
-### User Lists
-
-User lists to keep track of SaaS users for systems that are not easy to track in the admin consoles.
-
-- [Adobe User List](https://docs.google.com/spreadsheets/d/1xekApmAkp2xtBzck92X03nA4GMNJykrFmjdI4cvld58/edit#gid=573821992)
-- [Microsoft Word User List](https://docs.google.com/spreadsheets/d/1fhSTmoTmnkuPnFcpwAjcgJgZbaB5zaYN8y6UraFliuk/edit#gid=243236610)
-  - It’s unclear how many licenses we should be allowed/if we need to do a new contract with Microsoft. When I was handed the licenses, I was told they are unlimited, but I am not sure if that is actually the case.
-- [Mural User List](https://docs.google.com/spreadsheets/d/1DT_3_SDM8ezbaN3I0FnN3ZYVtJpgkyXqYkO54FcnBro/edit#gid=243236610)
-- [Sketch User List](https://docs.google.com/spreadsheets/d/1SCkLr0GXgoeqmIMPLic8QnX1INkyoP1YCNp17Sarx9s/edit#gid=243236610)
-
-SaaS Manager needs to be added to 18F Software and TTS Software Google groups
 
 ## Staff lists
 

--- a/how_we_work/ops_rotation.md
+++ b/how_we_work/ops_rotation.md
@@ -13,7 +13,6 @@ the context of the request. If you're not sure:
 We try to keep admin documentation and process close to the user documentation
 and process.
 
-
 ## Communications Monitoring
 
 You don't have to have the answers to all the questions, but you should ensure all the questions get answers.
@@ -21,9 +20,9 @@ You don't have to have the answers to all the questions, but you should ensure a
 ### Slack Channels
 
 | Channel name                                                                   |                                                                  Responsibility                                                                   |
-| ----------------------------                                                   | :-----------------------------------------------------------------------------------------------------------------------------------------------: |
+| ------------------------------------------------------------------------------ | :-----------------------------------------------------------------------------------------------------------------------------------------------: |
 | [#admins-dns](https://gsa-tts.slack.com/archives/C4L58EQ5T)                    |                                                           Look for failure for DNS jobs                                                           |
-| [#admins-emoji](https://gsa-tts.slack.com/archives/C024EBDS1NC)                |                                                     Recruit reviewers to approve emoji requests                                                   |
+| [#admins-emoji](https://gsa-tts.slack.com/archives/C024EBDS1NC)                |                                                    Recruit reviewers to approve emoji requests                                                    |
 | [#admins-github](https://gsa-tts.slack.com/archives/C02KXM98G)                 |                                       Typically used for folks to request new accounts or transfer accounts                                       |
 | [#admins-govdelivery](https://gsa-tts.slack.com/archives/CBQ490G3Y)            |                                                                      unsure                                                                       |
 | [#admins-hubspot](https://gsa-tts.slack.com/archives/C72F606QG)                |                                                                      unsure                                                                       |
@@ -52,8 +51,7 @@ It might be helpful [customize your sidebar](https://slack.com/help/articles/360
 | [TTS Vulnerability Reports](https://groups.google.com/a/gsa.gov/g/tts-vulnerability-reports) | Owner      |
 
 For the `TTS Software` group, we use [Google's Collaborative Inbox](https://support.google.com/a/answer/167430?hl=en)
-features to manage the status of requests. When on ops-rotation use the `Mark as
-Completed` to ensure others know a request has been satisfied. For requests that
+features to manage the status of requests. When on ops-rotation use the `Mark as Completed` to ensure others know a request has been satisfied. For requests that
 need assistance from others on the team, use the `Assign` feature to task them,
 include a description of what you need from them. Feel free to use any
 additional features you may find useful.
@@ -61,63 +59,3 @@ additional features you may find useful.
 It might be helpful to create a filter rule for each of the above
 `to:<list>@gsa.gov`s and add a label (e.g. `tech-portfolio`). Then
 [each day you can quickly process the queue](https://mail.google.com/mail/u/0/#search/label%3Atech-portfolio+is%3Aunread).
-
-## Knowledge Management
-
-- Handbook triage and maintenance
-  [Contributing to 18F Handbook](https://github.com/18F/handbook/blob/master/CONTRIBUTING.md)
-
-## System Management - Cloud Management
-
-[Creating new AWS accounts](https://before-you-ship.18f.gov/infrastructure/aws/#creating-new-accounts)
-
-## System Management - Software Management
-
-### Play: Managing Software requests
-
-Members of TTS will start the [request process](https://handbook.tts.gsa.gov/software/) when a user needs a piece of software that the TTS Tech Portfolio Manages. They will make a request by sending an email will be sent to tts-software@gsa.gov and show on the [Software Group](https://groups.google.com/a/gsa.gov/forum/?utm_medium=email&utm_source=footer#!forum/tts-software) and whomever is in rotation will answer it. Once the operations rotation receives the email they send a canned response to the requestor letting them know that they’ve gotten it. Once operations rotation person has completed all of their tasks, they will mark the item complete.
-
-Microsoft, Trello, Mural, and InVision require that you go into the back-end and manually add the person into the account.
-
-See the following [administration guide](https://docs.google.com/document/d/18Htav6TIgasBvvSroI8H_sQXxnvMlra2k9iabBwQYUs/edit#) and [document guide](https://github.com/18F/tts-tech-portfolio/blob/main/links.md) for links to the user lists, back-end accounts, and template responses.
-
-### Play: Microsoft Software Request
-
-Point them to [Office documentation](https://handbook.tts.gsa.gov/office/).
-
-### Play: Mural Software Request
-
-- [Mural How-To Guide](https://handbook.tts.gsa.gov/tools/mural/) - How to administer the TTS Mural account
-- [Mural user list](https://docs.google.com/spreadsheets/d/1V_1BoiM7A8fuqkvTFfv4Ma5ckc4NuesphX4OE58zgow/edit)
-
-### Play: Sketch Software Request
-
-[Sketch Handbook page](https://handbook.tts.gsa.gov/sketch/#for-admins)
-
-Canned Response:
-Please proceed with downloading and installing from the vendor:
-https://www.sketch.com/get/
-
-You have been granted access to the license you will need here:
-https://docs.google.com/document/d/1Qrn4J7mOcpGv51krZOyxpz93mBDp22hzl2wtVLulhUU/edit
-
-### Play: Omnigraffle Software Request
-
-- v6 (not 7+)
-- License Owner: 18F Software (GSA)
-- [Omnigraffle License key](https://docs.google.com/document/d/18k8yuM9oXQA7MNr-qvfq8gXliSHOb_bWElohb-KaObw/edit#)
-
-If employees are asking to be removed from Omigraffle, this software does not have that capability since it only inputs a code and there is not limit to users, Omnigraffle is just removed when the out boarded employee turns their Macbook in.
-
-### Play: Sublime Text Software Request
-
-[Sublime License Key](https://docs.google.com/document/d/1Oy-dh_s2T9KgOYLWs2tu4ZBe9nfIGj7PZWDOX3dQaLg/edit?ts=5ea1ecfe)
-
-### Play: Adobe Software Request
-
-Canned Response:
-
-You can request Acrobat Pro or Creative Cloud by submitting a Software Request through the GSA IT Help Desk. Make sure to specify that you are on a Mac.
-
-Thanks!
--TTS Tech Portfolio


### PR DESCRIPTION
Also added a link to the new [org chart](https://docs.google.com/spreadsheets/d/1hp8Xw2qbW9SUdahRFKr6I2pAcsg1LrxwD9HxDxfppcg/edit#gid=1627662065). (Access to that might be restricted — will figure that out in https://github.com/18F/handbook/issues/2714).